### PR TITLE
Enforce cart page login

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,7 +80,7 @@ function App() {
           element={<Login onSuccess={handleLoginSuccess} />}
         />
         <Route path="/trade" element={<TradeMyItems />} />
-        <Route path="/myOrdered" element={<MyOrderedItems />} />
+        <Route path="/orders" element={<MyOrderedItems />} />
         <Route
           path="/search"
           element={<SearchResult items={searchResults} query={searchQuery} />}
@@ -92,7 +92,7 @@ function App() {
         <Route path="/uploadItems" element={<UploadItems />} />
         <Route path="/updateItems" element={<UpdateItems />} />
         <Route path="/uploadSeccess" element={<UploadSuccessPage />} />
-        <Route path="/myCart" element={<MyCart />} />
+        <Route path="/cart" element={<MyCart />} />
         <Route path="/byCategory" element={<ItemDisplayByCategory />} />
         <Route path="/register" element={<Register />} />
         <Route path="/rating" element={<RateSellerPage />} />

--- a/src/App.js
+++ b/src/App.js
@@ -79,26 +79,8 @@ function App() {
           path="/login"
           element={<Login onSuccess={handleLoginSuccess} />}
         />
-        <Route
-          path="/trade"
-          element={
-            isLoggedIn ? (
-              <TradeMyItems />
-            ) : (
-              <Login onSuccess={handleLoginSuccess} />
-            )
-          }
-        />
-        <Route
-          path="/myOrdered"
-          element={
-            isLoggedIn ? (
-              <MyOrderedItems />
-            ) : (
-              <Login onSuccess={handleLoginSuccess} />
-            )
-          }
-        />
+        <Route path="/trade" element={<TradeMyItems />} />
+        <Route path="/myOrdered" element={<MyOrderedItems />} />
         <Route
           path="/search"
           element={<SearchResult items={searchResults} query={searchQuery} />}
@@ -110,7 +92,7 @@ function App() {
         <Route path="/uploadItems" element={<UploadItems />} />
         <Route path="/updateItems" element={<UpdateItems />} />
         <Route path="/uploadSeccess" element={<UploadSuccessPage />} />
-        <Route path="/MyCart" element={<MyCart />} />
+        <Route path="/myCart" element={<MyCart />} />
         <Route path="/byCategory" element={<ItemDisplayByCategory />} />
         <Route path="/register" element={<Register />} />
         <Route path="/rating" element={<RateSellerPage />} />

--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -239,7 +239,7 @@ export const CheckoutButton = ({ item, isLoggedIn }) => {
       try {
         await createTransaction(item);
         message.success("Order created!");
-        navigate("/myOrdered");
+        navigate("/orders");
       } catch (error) {
         message.error(error.message);
       }
@@ -281,7 +281,7 @@ export const CartCheckoutButton = ({ items, selectedRowKeys, disabled }) => {
       );
       await deleteMultipleCartItems(selectedRowKeys);
       message.success("Order created!");
-      navigate("/myOrdered");
+      navigate("/orders");
     } catch (error) {
       message.error(error.message);
     }
@@ -319,7 +319,7 @@ export function AddToCartButton({ item, isLoggedIn }) {
       try {
         await addToCart(item);
         message.success("Order created!");
-        navigate("/myCart");
+        navigate("/cart");
       } catch (error) {
         message.error(error.message);
       }

--- a/src/components/HeaderMenu.js
+++ b/src/components/HeaderMenu.js
@@ -111,7 +111,7 @@ const HeaderMenu = ({
             </Menu.Item>
             <Menu.Item key="myOrdered" icon={<ShoppingOutlined />}>
               <Link
-                to={isLoggedIn ? "/myOrdered" : "/login"}
+                to={isLoggedIn ? "/orders" : "/login"}
                 style={{
                   color: "white",
                   font: "Arial",
@@ -124,7 +124,7 @@ const HeaderMenu = ({
             </Menu.Item>
             <Menu.Item key="MyCart" icon={<ShoppingCartOutlined />}>
               <Link
-                to={isLoggedIn ? "/myCart" : "/login"}
+                to={isLoggedIn ? "/cart" : "/login"}
                 style={{
                   color: "white",
                   font: "Arial",

--- a/src/components/HeaderMenu.js
+++ b/src/components/HeaderMenu.js
@@ -1,7 +1,6 @@
 import { Button, Layout, Menu } from "antd";
 import { Link, useNavigate } from "react-router-dom";
 import Search from "antd/lib/input/Search";
-import { searchItems } from "../utils";
 import {
   ShoppingCartOutlined,
   ShoppingOutlined,
@@ -99,7 +98,7 @@ const HeaderMenu = ({
 
             <Menu.Item key="trade" icon={<SwapOutlined />}>
               <Link
-                to="/trade"
+                to={isLoggedIn ? "/trade" : "/login"}
                 style={{
                   color: "white",
                   font: "Arial",
@@ -112,7 +111,7 @@ const HeaderMenu = ({
             </Menu.Item>
             <Menu.Item key="myOrdered" icon={<ShoppingOutlined />}>
               <Link
-                to="/myOrdered"
+                to={isLoggedIn ? "/myOrdered" : "/login"}
                 style={{
                   color: "white",
                   font: "Arial",
@@ -125,7 +124,7 @@ const HeaderMenu = ({
             </Menu.Item>
             <Menu.Item key="MyCart" icon={<ShoppingCartOutlined />}>
               <Link
-                to="/MyCart"
+                to={isLoggedIn ? "/myCart" : "/login"}
                 style={{
                   color: "white",
                   font: "Arial",

--- a/src/components/MyOrderedItemPage.js
+++ b/src/components/MyOrderedItemPage.js
@@ -1,4 +1,4 @@
-import { Layout } from "antd";
+import { Layout, message } from "antd";
 import React, { useEffect, useState } from "react";
 import TransactionsDisplay from "./TransactionsDisplay";
 import { fetchTransactionsAsBuyer } from "../utils";
@@ -8,8 +8,12 @@ function MyOrderedItems() {
 
   useEffect(() => {
     const fetchOrders = async () => {
-      const myOrders = await fetchTransactionsAsBuyer();
-      setOrders(myOrders);
+      try {
+        const myOrders = await fetchTransactionsAsBuyer();
+        setOrders(myOrders);
+      } catch (error) {
+        message.error(error.message);
+      }
     };
     fetchOrders();
   }, []);

--- a/src/components/RateSellerPage.js
+++ b/src/components/RateSellerPage.js
@@ -50,7 +50,7 @@ const RateSellerPage = () => {
     try {
       rateSeller(transaction.id, data.rating);
       message.success("Thank you for your rating!");
-      navigate("/myOrdered");
+      navigate("/orders");
     } catch (e) {
       message.error(e.message);
     }


### PR DESCRIPTION
The logic for enforcing that users are logged in before they can see their items, orders, and cart is rendering the login page at the `/trade`, `/orders`, and `/cart` paths. This is a problem because if users refresh the page we will try to fetch data and will fail because no user is logged in, displaying error messages.

Now, when we click on the header menu buttons without logging in, we're redirected to the `/login` page, preventing the previous error.